### PR TITLE
Add shared zuul-jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,3 @@
+- project:
+    templates:
+      - network-collections-migration


### PR DESCRIPTION
This adds test coverage with our network-collection-migration jobs.

Depends-On: https://github.com/ansible-network/network_collections_migration/pull/17
Depends-On: https://github.com/ansible-network/network_collections_migration/pull/18
Signed-off-by: Paul Belanger <pabelanger@redhat.com>